### PR TITLE
Fix serialization of chars

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -248,7 +248,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         let parser = sym(b'"') * (char_string | utf16_string) - sym(b'"');
 
         match parser.parse(&mut self.input) {
-            Ok(string) => visitor.visit_str(&string),
+            Ok(string) => visitor.visit_string(string),
             Err(_) => Err(Error::ExpectedString)
         }
     }
@@ -679,5 +679,17 @@ mod tests {
             (true,false,):4,
             (false,false,):123,
         }"));
+    }
+
+    #[test]
+    fn test_string() {
+        let s: String = from_str("\"String\"").unwrap();
+
+        assert_eq!("String", s);
+    }
+
+    #[test]
+    fn test_char() {
+        assert_eq!(Ok('c'), from_str("'c'"));
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -113,7 +113,10 @@ impl<'a> ser::Serializer for &'a mut Serializer {
     }
 
     fn serialize_char(self, v: char) -> Result<()> {
-        self.serialize_str(&v.to_string())
+        self.output += "'";
+        self.output.push(v);
+        self.output += "'";
+        Ok(())
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
@@ -495,5 +498,15 @@ mod tests {
         s.contains("(true,false,):4");
         s.contains("(false,false,):123");
         s.ends_with("}");
+    }
+
+    #[test]
+    fn test_string() {
+        assert_eq!(to_string(&"Some string").unwrap(), "\"Some string\"");
+    }
+
+    #[test]
+    fn test_char() {
+        assert_eq!(to_string(&'c').unwrap(), "'c'");
     }
 }


### PR DESCRIPTION
Previously, chars were serialized like strings, with `""`.